### PR TITLE
Create a dependabot file

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://help.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: "gomod" # See documentation for possible values
+    directory: "/" # Location of package manifests
+    schedule:
+      interval: "weekly"
+    labels:
+      - "dependencies"


### PR DESCRIPTION
Similar to pajbot1, I've added a config to update the dependencies for pajbot2 on a weekly basis. This is meant to replace the old `Dependabot Previews` integration. The integration will need to be uninstalled from the repo and all the dependabot settings will need to be enabled here: https://github.com/pajbot/pajbot2/settings/security_analysis (prior to merging).

Dependabot will check `go.mod` and `go.sum` for all dependencies. You can ignore specific dependencies using the config docs here: https://help.github.com/github/administering-a-repository/configuration-options-for-dependency-updates