### PR TITLE
Add npm dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,9 +5,15 @@
 
 version: 2
 updates:
-  - package-ecosystem: "gomod" # See documentation for possible values
-    directory: "/" # Location of package manifests
+  - package-ecosystem: "gomod"
+    directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "daily"
+    labels:
+      - "dependencies"
+  - package-ecosystem: "npm"
+    directory: "/web"
+    schedule:
+      interval: "daily"
     labels:
       - "dependencies"


### PR DESCRIPTION
Noticed that this needed to be added based on an http-proxy vulnerability alert that I got. It will now update the packages in the `/web` folder.
Also made the go dependencies check daily as opposed to weekly.