### PR TITLE
Force dependabot to update to major dep versions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,6 +17,7 @@ updates:
       interval: "daily"
     labels:
       - "dependencies"
+    versioning-strategy: increase
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:


### PR DESCRIPTION
Related conversations: https://github.com/pajbot/pajbot2/pull/188