### PR TITLE
Fix global perms not being recognized in nuke module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unversioned
 
+- The nuke module will now recognize users with global permissions.
 - Message height limit no longer applies to Twitch Moderators (#89, #228)
 - The version of MessageHeightTwitch was updated, which requires version 3.0 of .NET Core.
 - Changed DB backend from MySQL to PostgreSQL.  

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unversioned
 
-- The nuke module will now recognize users with global permissions.
+- The nuke module will now recognize users with global permissions. (#268)
 - Message height limit no longer applies to Twitch Moderators (#89, #228)
 - The version of MessageHeightTwitch was updated, which requires version 3.0 of .NET Core.
 - Changed DB backend from MySQL to PostgreSQL.  

--- a/pkg/modules/nuke.go
+++ b/pkg/modules/nuke.go
@@ -68,7 +68,7 @@ func newNuke(b *mbase.Base) pkg.Module {
 }
 
 func (m *nukeModule) Trigger(parts []string, event pkg.MessageEvent) pkg.Actions {
-	if !(event.User.IsModerator() || event.User.HasChannelPermission(m.BotChannel().Channel(), pkg.PermissionModeration)) {
+	if !(event.User.IsModerator() || event.User.HasPermission(m.BotChannel().Channel(), pkg.PermissionModeration)) {
 		return nil
 	}
 


### PR DESCRIPTION
In order to use the whisper nuke, users would have to give themselves/have the channel moderation permission given to them; despite already having global moderation permissions. This pr will also recognize global permissions.