### PR TITLE
Fix potential security risk regarding external links

### DIFF
--- a/web/src/js/Dashboard.jsx
+++ b/web/src/js/Dashboard.jsx
@@ -164,6 +164,7 @@ export default class Dashboard extends Component {
                   <a
                     target="_blank"
                     href={`https://logs.ivr.fi/?channel=${report.Channel.Name}&username=${report.Target.Name}`}
+                    rel="noopener noreferrer"
                   >
                     &nbsp;logs
                   </a>


### PR DESCRIPTION
I don't see this being the biggest issue, since the logs belong to a secure user and you can only get to the logs by logging into the dashboard, but it's good to keep things as secure as possible.

PR relates to this code scanning alert: https://github.com/pajbot/pajbot2/security/code-scanning/8?query=ref%3Arefs%2Fheads%2Fmaster