### PR TITLE
Move nuke module to its own package

### DIFF
--- a/cmd/bot/minit.go
+++ b/cmd/bot/minit.go
@@ -14,4 +14,6 @@ import (
 	_ "github.com/pajbot/pajbot2/pkg/modules/giveaway"
 
 	_ "github.com/pajbot/pajbot2/pkg/modules/link_filter"
+
+	_ "github.com/pajbot/pajbot2/pkg/modules/nuke"
 )

--- a/pkg/modules/nuke/m.go
+++ b/pkg/modules/nuke/m.go
@@ -1,4 +1,4 @@
-package modules
+package nuke
 
 import (
 	"fmt"
@@ -9,19 +9,14 @@ import (
 
 	"github.com/pajbot/pajbot2/pkg"
 	"github.com/pajbot/pajbot2/pkg/commands"
+	"github.com/pajbot/pajbot2/pkg/modules"
 	mbase "github.com/pajbot/pajbot2/pkg/modules/base"
 	"github.com/pajbot/pajbot2/pkg/twitchactions"
 )
 
 func init() {
-	Register("nuke", func() pkg.ModuleSpec {
-		return &Spec{
-			id:    "nuke",
-			name:  "Nuke",
-			maker: newNuke,
-
-			enabledByDefault: true,
-		}
+	modules.Register("nuke", func() pkg.ModuleSpec {
+		return modules.NewSpec("nuke", "Nuke", true, newNuke)
 	})
 }
 


### PR DESCRIPTION
- Move float and bool parameters to their own files
- rename parameters.go to param.go
- Move nuke module to its own package
