### PR TITLE
Bump minimum Go version to 1.15

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,7 @@ jobs:
 
     strategy:
       matrix:
-        go: [1.14, 1.15]
+        go: [1.15, 1.16]
 
     steps:
       - name: Set up Go

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -14,7 +14,7 @@ jobs:
 
     strategy:
       matrix:
-        go: [1.14, 1.15]
+        go: [1.15, 1.16]
 
     steps:
       - name: Set up Go

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/pajbot/pajbot2
 
-go 1.11
+go 1.15
 
 require (
 	github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751


### PR DESCRIPTION
Updated workflows to use newer Go version and reflected that change in `go.mod`, which should have the minimal supported version of Go.
I think this change also requires maintainers to update required checks in the repository settings.