### PR TITLE
Count runes instead of bytes in MessageLengthLimit module

### DIFF
--- a/pkg/modules/message_length_limit.go
+++ b/pkg/modules/message_length_limit.go
@@ -2,6 +2,7 @@ package modules
 
 import (
 	"time"
+	"unicode/utf8"
 
 	"github.com/pajbot/pajbot2/pkg"
 	mbase "github.com/pajbot/pajbot2/pkg/modules/base"
@@ -33,7 +34,7 @@ func newMessageLengthLimit(b *mbase.Base) pkg.Module {
 func (m MessageLengthLimit) OnMessage(event pkg.MessageEvent) pkg.Actions {
 	message := event.Message
 
-	messageLength := len(message.GetText())
+	messageLength := utf8.RuneCountInString(message.GetText())
 	if messageLength > 140 {
 		if messageLength > 420 {
 			return twitchactions.DoTimeout(event.User, 600*time.Second, "Your message is way too long")


### PR DESCRIPTION
Using just `len()` on a string would return for example 2 characters for some emoji etc, this is more accurate. Documentation of func: https://pkg.go.dev/unicode/utf8#RuneCountInString