### PR TITLE
Update dotnet/alpine base image for Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,13 @@
-FROM mcr.microsoft.com/dotnet/sdk:6.0.200-alpine3.14 AS build
+FROM mcr.microsoft.com/dotnet/sdk:6.0.301-1-alpine3.16 AS build
 RUN apk add --no-cache go nodejs npm build-base
 ADD . /src
 RUN cd /src && ./utils/install.sh
 RUN cd /src && ./utils/build.sh -v -tags csharp
 
-FROM mcr.microsoft.com/dotnet/runtime:6.0.2-alpine3.14
+FROM mcr.microsoft.com/dotnet/runtime:6.0.6-alpine3.16
 WORKDIR /app/cmd/bot
 RUN apk add --no-cache icu
-ENV LIBCOREFOLDER /usr/share/dotnet/shared/Microsoft.NETCore.App/6.0.2
+ENV LIBCOREFOLDER /usr/share/dotnet/shared/Microsoft.NETCore.App/6.0.6
 COPY --from=build /src/web/static /app/web/static
 COPY --from=build /src/web/views /app/web/views
 COPY --from=build /src/cmd/bot/bot /app/cmd/bot/bot


### PR DESCRIPTION
Go is updated to 1.18 and Node.js is updated to 16 with this update aswell.

Tested to be working fine with my test instance.