### PR TITLE
Allow some !pb2exec commands to be used with Twitch User IDs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unversioned
 
+- Allow pb2exec commands `ban`, `unban`, `timeout`, `untimeout` to be used with IDs (e.g. `!pb2exec .timeout id:22484632 5 reason`). (#1056)
 - Remove Twitter support. (#1033)  
   Warning messages will be posted in the console if twitter tokens are configured.
 - Add GitHub push event webhook support. (#1042)  

--- a/cmd/bot/twitchuserstore.go
+++ b/cmd/bot/twitchuserstore.go
@@ -112,6 +112,15 @@ func (s *UserStore) GetID(name string) (id string) {
 	return
 }
 
+func (s *UserStore) GetUserByID(userID string) (pkg.User, error) {
+	login := s.GetName(userID)
+	if userID == "" {
+		return nil, fmt.Errorf("no user found with the userID %s", userID)
+	}
+
+	return users.NewSimpleTwitchUser(userID, login), nil
+}
+
 func (s *UserStore) GetUserByLogin(login string) (pkg.User, error) {
 	userID := s.GetID(login)
 	if userID == "" {

--- a/pkg/modules/debug.go
+++ b/pkg/modules/debug.go
@@ -90,9 +90,13 @@ func (c *pb2Exec) Trigger(parts []string, event pkg.MessageEvent) pkg.Actions {
 			return nil, errors.New("no target specified")
 		}
 
-		login := strings.ToLower(parts[2])
+		target := strings.ToLower(parts[2])
 
-		return event.UserStore.GetUserByLogin(login)
+		if strings.HasPrefix(target, "id:") {
+			return event.UserStore.GetUserByID(strings.TrimPrefix(target, "id:"))
+		}
+
+		return event.UserStore.GetUserByLogin(target)
 	}
 
 	parseDuration := func(t string, defaultUnit time.Duration, defaultTime time.Duration) time.Duration {

--- a/pkg/userstore.go
+++ b/pkg/userstore.go
@@ -60,6 +60,7 @@ type UserStore interface {
 	GetID(string) string
 
 	GetUserByLogin(string) (User, error)
+	GetUserByID(string) (User, error)
 
 	GetName(string) string
 


### PR DESCRIPTION
Allow ban, unban, timeout, untimeout to be used with ids

Usage: `!pb2exec .timeout id:22484632 5 reason`

Fixes #1053
